### PR TITLE
add additional date parsing formats

### DIFF
--- a/app/utils/file_parser.py
+++ b/app/utils/file_parser.py
@@ -15,13 +15,19 @@ def parse_whatsapp_chat(file):
             message = match.group(3)
             # Check if the message is not a placeholder for media
             if message not in ["audio omitted", "image omitted", "video omitted"]:
-                # Normalize the timestamp by replacing "a.m." and "p.m." with "AM" and "PM"
+           
                 timestamp = timestamp.replace(' a.m.', ' AM').replace(' p.m.', ' PM').replace('a.m.', ' AM').replace('p.m.', ' PM')
                 
                 # List of possible date formats to handle various cases
                 date_formats = [
-                    '%m/%d/%y, %I:%M:%S %p',
-                    '%d/%m/%y, %I:%M:%S %p'
+                    '%m/%d/%y, %I:%M:%S %p',  # 08/12/24, 8:57:27 PM
+                    '%d/%m/%y, %I:%M:%S %p',  # 12/08/24, 8:57:27 PM
+                    '%d/%m/%Y %H:%M:%S',      # 23/05/2024 21:44:49 (24-hour format)
+                    '%m/%d/%y, %I:%M:%S %p',  # 08/12/24, 08:57:27 AM
+                    '%d/%m/%y, %I:%M:%S %p',  # 12/08/24, 08:57:27 AM
+                    '%d/%m/%y, %H:%M:%S',     # 23/05/24, 21:44:49 (24-hour format)
+                    '%d/%m/%Y, %H:%M:%S',     # 23/05/2024, 21:44:49 (24-hour format with full year)
+                    '%m/%d/%Y, %I:%M:%S %p'   # 08/12/2024, 8:57:27 PM
                 ]
                 
                 for date_format in date_formats:

--- a/tests/test_parse_whatsapp_chat.py
+++ b/tests/test_parse_whatsapp_chat.py
@@ -37,5 +37,37 @@ class TestParseWhatsappChat(unittest.TestCase):
         with self.assertRaises(ValueError):
             parse_whatsapp_chat(BytesIO(chat_data))
 
+    def test_24_hour_format(self):
+        chat_data = b"[23/05/2024 21:44:49] Alice: Good evening!\n[23/05/2024 08:30:15] Bob: Good morning!"
+        df = parse_whatsapp_chat(BytesIO(chat_data))
+        self.assertEqual(len(df), 2)
+        self.assertEqual(df.iloc[0]['Sender'], 'Alice')
+        self.assertEqual(df.iloc[1]['Sender'], 'Bob')
+    
+    #not expected; but just in case
+    def test_mixed_formats(self):
+        chat_data = b"[12/01/23, 03:45:12 p.m.] John: Hello!\n[23/05/2024 21:44:49] Jane: How's it going?"
+        df = parse_whatsapp_chat(BytesIO(chat_data))
+        self.assertEqual(len(df), 2)
+        self.assertEqual(df.iloc[0]['Sender'], 'John')
+        self.assertEqual(df.iloc[1]['Sender'], 'Jane')
+
+    def test_omitted_media_multiple_entries(self):
+        chat_data = b"[12/01/23, 03:45:12 p.m.] John: audio omitted\n[12/01/23, 03:46:12 p.m.] Jane: image omitted\n[12/01/23, 03:47:12 p.m.] John: How are you?"
+        df = parse_whatsapp_chat(BytesIO(chat_data))
+        self.assertEqual(len(df), 1)  # Two messages should be skipped
+        self.assertEqual(df.iloc[0]['Sender'], 'John')
+        self.assertEqual(df.iloc[0]['Message'], 'How are you?')
+
+    def test_case_with_empty_file(self):
+        chat_data = b""
+        df = parse_whatsapp_chat(BytesIO(chat_data))
+        self.assertEqual(len(df), 0)  # DataFrame should be empty
+
+    def test_case_with_only_media_omitted(self):
+        chat_data = b"[12/01/23, 03:45:12 p.m.] John: audio omitted\n[12/01/23, 03:46:12 p.m.] Jane: video omitted"
+        df = parse_whatsapp_chat(BytesIO(chat_data))
+        self.assertEqual(len(df), 0)  # DataFrame should be empty as both messages are media omitted
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added support for additional formats:

- %d/%m/%Y %H:%M:%S: Handles 23/05/2024 21:44:49 format (24-hour time, full year).
- %d/%m/%y, %H:%M:%S: Handles 23/05/24, 21:44:49 (24-hour time, short year).
- Other combinations of day-first, month-first, AM/PM, and 24-hour time formats.